### PR TITLE
#106 #110 Several Display Issues of Shanghai Metro Indoor Map

### DIFF
--- a/src/constants/templates/shmetro/sh1.ts
+++ b/src/constants/templates/shmetro/sh1.ts
@@ -1,5 +1,5 @@
 const params = {
-    "svg_height": 300,
+    "svg_height": 400,
     "padding": 8.750201061605276,
     "y_pc": 40,
     "branch_spacing": 45,

--- a/src/constants/templates/shmetro/sh1.ts
+++ b/src/constants/templates/shmetro/sh1.ts
@@ -1088,7 +1088,8 @@ const params = {
     "svgWidth": {
         "destination": 1600,
         "runin": 1200,
-        "railmap": 1800
+        "railmap": 2000,
+        "indoor": 2500,
     },
     "notesGZMTR": [],
     "namePosMTR": {

--- a/src/constants/templates/shmetro/sh11.ts
+++ b/src/constants/templates/shmetro/sh11.ts
@@ -1,8 +1,8 @@
 const params = {
-    svg_height: 450,
+    svg_height: 500,
     padding: 2.88,
     y_pc: 40,
-    branch_spacing: 64.51,
+    branch_spacing: 75.2,
     theme: [
         "shanghai",
         "sh11",
@@ -1387,7 +1387,7 @@ const params = {
         destination: 1500,
         runin: 1500,
         railmap: 2200,
-        indoor: 3000,
+        indoor: 3500,
     },
     notesGZMTR: [],
     namePosMTR: {

--- a/src/constants/templates/shmetro/sh11.ts
+++ b/src/constants/templates/shmetro/sh11.ts
@@ -1,5 +1,5 @@
 const params = {
-    svg_height: 330,
+    svg_height: 450,
     padding: 2.88,
     y_pc: 40,
     branch_spacing: 64.51,

--- a/src/constants/templates/shmetro/sh16.ts
+++ b/src/constants/templates/shmetro/sh16.ts
@@ -1,5 +1,5 @@
 const params = {
-    svg_height: 400,
+    svg_height: 450,
     padding: 8.750201061605276,
     y_pc: 40,
     branch_spacing: 45,

--- a/src/constants/templates/shmetro/sh16.ts
+++ b/src/constants/templates/shmetro/sh16.ts
@@ -1,5 +1,5 @@
 const params = {
-    svg_height: 300,
+    svg_height: 400,
     padding: 8.750201061605276,
     y_pc: 40,
     branch_spacing: 45,

--- a/src/constants/templates/shmetro/sh2.ts
+++ b/src/constants/templates/shmetro/sh2.ts
@@ -1,5 +1,5 @@
 const params = {
-    svg_height: 400,
+    svg_height: 500,
     padding: 3.47,
     y_pc: 68.02,
     branch_spacing: 64.32,
@@ -1145,7 +1145,8 @@ const params = {
     svgWidth: {
         destination: 1500,
         runin: 1500,
-        railmap: 2000
+        railmap: 2000,
+        indoor: 3000,
     },
     notesGZMTR: [],
     namePosMTR: {

--- a/src/constants/templates/shmetro/sh2.ts
+++ b/src/constants/templates/shmetro/sh2.ts
@@ -1,5 +1,5 @@
 const params = {
-    svg_height: 300,
+    svg_height: 400,
     padding: 3.47,
     y_pc: 68.02,
     branch_spacing: 64.32,

--- a/src/constants/templates/shmetro/sh5.ts
+++ b/src/constants/templates/shmetro/sh5.ts
@@ -1,5 +1,5 @@
 const params = {
-    svg_height: 350,
+    svg_height: 450,
     padding: 8.750201061605276,
     y_pc: 40,
     branch_spacing: 45,

--- a/src/constants/templates/shmetro/sh6.ts
+++ b/src/constants/templates/shmetro/sh6.ts
@@ -1,5 +1,5 @@
 const params = {
-    "svg_height": 300,
+    "svg_height": 400,
     "padding": 8.750201061605276,
     "y_pc": 40,
     "branch_spacing": 38.5,

--- a/src/constants/templates/shmetro/sh6.ts
+++ b/src/constants/templates/shmetro/sh6.ts
@@ -1,5 +1,5 @@
 const params = {
-    "svg_height": 400,
+    "svg_height": 450,
     "padding": 8.750201061605276,
     "y_pc": 40,
     "branch_spacing": 38.5,
@@ -1031,7 +1031,8 @@ const params = {
     "svgWidth": {
         "destination": 1500,
         "runin": 1500,
-        "railmap": 1500
+        "railmap": 1500,
+        "indoor": 2500,
     },
     "notesGZMTR": [],
     "namePosMTR": {

--- a/src/constants/templates/shmetro/sh7.ts
+++ b/src/constants/templates/shmetro/sh7.ts
@@ -1227,7 +1227,8 @@ const params = {
     "svgWidth": {
         "destination": 1500,
         "runin": 1500,
-        "railmap": 2000
+        "railmap": 2000,
+        "indoor": 2500,
     },
     "notesGZMTR": [],
     "namePosMTR": {

--- a/src/constants/templates/shmetro/sh7.ts
+++ b/src/constants/templates/shmetro/sh7.ts
@@ -1,5 +1,5 @@
 const params = {
-    "svg_height": 300,
+    "svg_height": 400,
     "padding": 8.750201061605276,
     "y_pc": 40,
     "branch_spacing": 45,

--- a/src/constants/templates/shmetro/sh8.ts
+++ b/src/constants/templates/shmetro/sh8.ts
@@ -1,5 +1,5 @@
 const params = {
-    "svg_height": 300,
+    "svg_height": 400,
     "padding": 8.750201061605276,
     "y_pc": 40,
     "branch_spacing": 42.07,

--- a/src/constants/templates/shmetro/sh8.ts
+++ b/src/constants/templates/shmetro/sh8.ts
@@ -1080,7 +1080,8 @@ const params = {
     "svgWidth": {
         "destination": 1500,
         "runin": 1500,
-        "railmap": 2000
+        "railmap": 2000,
+        "indoor": 2500,
     },
     "notesGZMTR": [],
     "namePosMTR": {

--- a/src/svgs/indoor/indoor-shmetro.tsx
+++ b/src/svgs/indoor/indoor-shmetro.tsx
@@ -100,7 +100,7 @@ const IndoorSHMetro = () => {
     );
 
     return (
-        <g id="main" transform={`translate(0,${param.svg_height - 150})`}>
+        <g id="main" transform={`translate(0,${param.svg_height - 200})`}>
             <Lines paths={linePaths} />
             <StationGroup xs={xs} ys={ys} xShares={xShares} stnStates={stnStates} />
             <InfoElements />
@@ -159,35 +159,39 @@ const InfoElements = () => {
     const { param } = useContext(ParamContext);
 
     return React.useMemo(() => (
-        <g transform={`translate(${param.svgWidth.indoor / 2},-120)`}>
-            <g transform="translate(-800,210)">
-                <rect x="-5" y="-25" width="100" height="70" fill="none" stroke="black" rx="5"></rect>
-                <line x1="30" x2="30" y1="-20" y2="40" stroke="black"></line>
-                <text className="rmg-name__zh" dx="3" fontSize="18">图</text>
-                <text className="rmg-name__zh" dx="3" dy="18" fontSize="18">例</text>
-                <text className="rmg-name__en" dy="35" fontSize="8">legend</text>
-                <use
-                    transform="translate(45,10)"
-                    xlinkHref="#int2_indoor_sh"
-                    stroke="var(--rmg-theme-colour)"
-                />
-                <text className="rmg-name__zh" dx="60" dy="10" fontSize="10">换乘站</text>
-                <text className="rmg-name__en" dx="60" dy="20" fontSize="6">Interchange</text>
-                <text className="rmg-name__en" dx="60" dy="30" fontSize="6">Station</text>
+        <>
+            <g transform={`translate(${param.svgWidth.indoor / 2},${-param.svg_height+250})`}>
+                <text textAnchor="middle" fontSize="30" className="rmg-name__zh">
+                    轨道交通{param.line_name[0]}运营线路示意图
+                </text>
             </g>
-            <text textAnchor="middle" fontSize="30" className="rmg-name__zh">
-                轨道交通{param.line_name[0]}运营线路示意图
-            </text>
-            <text textAnchor="middle" fontSize="18" className="rmg-name__zh" dx="-100" dy="230">
-                友情提示：请留意您需要换乘线路的首末班时间，以免耽误您的出行，末班车进站前三分钟停售该末班车车票。
-            </text>
-            <text textAnchor="middle" fontSize="12" className="rmg-name__en" dx="-60" dy="250">
-                Please pay attention to the interchange schedule if you want to transfer to other lines. Stop selling tickets 3 minutes before the last train services.
-            </text>
-        </g>
+            <g transform={`translate(${param.svgWidth.indoor / 2},-100)`}>
+                <text textAnchor="middle" fontSize="18" className="rmg-name__zh" dx="-30" dy="230">
+                    友情提示：请留意您需要换乘线路的首末班时间，以免耽误您的出行，末班车进站前三分钟停售该末班车车票。
+                </text>
+                <text textAnchor="middle" fontSize="12" className="rmg-name__en" dx="10" dy="250">
+                    Please pay attention to the interchange schedule if you want to transfer to other lines. Stop selling tickets 3 minutes before the last train services.
+                </text>
+                <g transform="translate(-600,215)">
+                    <rect x="-5" y="-25" width="100" height="70" fill="none" stroke="black" rx="5"></rect>
+                    <line x1="30" x2="30" y1="-20" y2="40" stroke="black"></line>
+                    <text className="rmg-name__zh" dx="3" fontSize="18">图</text>
+                    <text className="rmg-name__zh" dx="3" dy="18" fontSize="18">例</text>
+                    <text className="rmg-name__en" dy="35" fontSize="8">legend</text>
+                    <use
+                        transform="translate(45,10)"
+                        xlinkHref="#int2_indoor_sh"
+                        stroke="var(--rmg-theme-colour)"
+                    />
+                    <text className="rmg-name__zh" dx="60" dy="10" fontSize="10">换乘站</text>
+                    <text className="rmg-name__en" dx="60" dy="20" fontSize="6">Interchange</text>
+                    <text className="rmg-name__en" dx="60" dy="30" fontSize="6">Station</text>
+                </g>
+            </g>
+        </>
     ),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [param.svgWidth.indoor]);
+        [param.svgWidth.indoor, param.svg_height]);
 };
 
 /* Some unused functions to split branches from the main line.

--- a/src/svgs/indoor/indoor-shmetro.tsx
+++ b/src/svgs/indoor/indoor-shmetro.tsx
@@ -16,12 +16,11 @@ export default memo(function IndoorWrapperSHMetro() {
 
 export const DefsSHMetro = React.memo(() => (
     <defs>
-        <circle id="stn_indoor_sh" fill="white" strokeWidth={5} stroke="var(--rmg-theme-colour)" r={8} />
+        <circle id="stn_indoor_sh" fill="white" strokeWidth={5} stroke="var(--rmg-theme-colour)"
+            r={8} transform="scale(1.5)" />
         <path id="int2_indoor_sh" fill="white" strokeWidth={4} d="M -5,0 a 5,5 0 1 1 10,0 V10 a 5,5 0 1 1 -10,0Z"
-            stroke="black" transform="translate(0, -6.5)scale(1.33)" />
-        <path id="express_sh" fill="white" strokeWidth={2} d="M -5,0 a 5,5 0 1 1 10,0 V25 a 5,5 0 1 1 -10,0Z" />
-        <path id="direct_sh" fill="whitef" strokeWidth={2} d="M -5,0 a 5,5 0 1 1 10,0 V50 a 5,5 0 1 1 -10,0Z" />
-        <path id="int_indoor_arrow_sh" stroke="black" strokeWidth={1} d="M -7.5,0 v -30 h -7.5 l 15,-15 l 15,15 h -7.5 v 30 Z " />
+            stroke="black" transform="translate(0, -10)scale(2)" />
+        <path id="int_indoor_arrow_sh" stroke="black" strokeWidth={1} d="M -7.5,0 v -40 h -7.5 l 15,-15 l 15,15 h -7.5 v 40 Z " />
     </defs>
 ));
 
@@ -113,7 +112,7 @@ const IndoorSHMetro = () => {
 const Lines = React.memo(
     (props: { paths: { main: string[]; pass: string[] } }) => {
         return (
-            <g fill="none" strokeWidth={9.68}>
+            <g fill="none" strokeWidth={12}>
                 <g stroke="var(--rmg-theme-colour)">
                     {props.paths.main.map((path, i) => (
                         <path key={i} d={path} />

--- a/src/svgs/indoor/indoor-shmetro.tsx
+++ b/src/svgs/indoor/indoor-shmetro.tsx
@@ -100,11 +100,13 @@ const IndoorSHMetro = () => {
     );
 
     return (
-        <g id="main" transform={`translate(0,${param.svg_height - 200})`}>
-            <Lines paths={linePaths} />
-            <StationGroup xs={xs} ys={ys} xShares={xShares} stnStates={stnStates} />
+        <>
+            <g id="main" transform={`translate(0,${param.svg_height / 2})`}>
+                <Lines paths={linePaths} />
+                <StationGroup xs={xs} ys={ys} xShares={xShares} stnStates={stnStates} />
+            </g>
             <InfoElements />
-        </g>
+        </>
     );
 }
 
@@ -141,14 +143,14 @@ const StationGroup = (props: StationGroupProps) => {
             {Object.keys(param.stn_list)
                 .filter(stnId => !['linestart', 'lineend'].includes(stnId))
                 .map(stnId => (<g key={stnId} transform={`translate(${props.xs[stnId]},${props.ys[stnId]})`}>
-                        <StationSHMetro
-                            stnId={stnId}
-                            stnState={props.stnStates[stnId]}
-                            nameDirection={branches
-                                .filter(branch => branch.includes(stnId))
-                                .map(branch => branch.indexOf(stnId) % 2 === 0 ?
-                                    'downward' : 'upward')[0] as 'upward' | 'downward'} />
-                    </g>)
+                    <StationSHMetro
+                        stnId={stnId}
+                        stnState={props.stnStates[stnId]}
+                        nameDirection={branches
+                            .filter(branch => branch.includes(stnId))
+                            .map(branch => branch.indexOf(stnId) % 2 === 0 ?
+                                'downward' : 'upward')[0] as 'upward' | 'downward'} />
+                </g>)
                 )
             }
         </g>
@@ -160,12 +162,12 @@ const InfoElements = () => {
 
     return React.useMemo(() => (
         <>
-            <g transform={`translate(${param.svgWidth.indoor / 2},${-param.svg_height+250})`}>
+            <g transform={`translate(${param.svgWidth.indoor / 2},50)`}>
                 <text textAnchor="middle" fontSize="30" className="rmg-name__zh">
                     轨道交通{param.line_name[0]}运营线路示意图
                 </text>
             </g>
-            <g transform={`translate(${param.svgWidth.indoor / 2},-100)`}>
+            <g transform={`translate(${param.svgWidth.indoor / 2},${param.svg_height - 300})`}>
                 <text textAnchor="middle" fontSize="18" className="rmg-name__zh" dx="-30" dy="230">
                     友情提示：请留意您需要换乘线路的首末班时间，以免耽误您的出行，末班车进站前三分钟停售该末班车车票。
                 </text>
@@ -198,7 +200,7 @@ const InfoElements = () => {
  * Note the branches here has a slightly different meaning.
  * It refers to all the line sections that have a parallel line
  * rather than the upper or the bottom branch section.
- * 
+ *
  * Currently these functions only can be used on a line that
  * branches in the middle and ends at the linestart, which also
  * means that linestart has two children in the adjMat.

--- a/src/svgs/indoor/station-shmetro.tsx
+++ b/src/svgs/indoor/station-shmetro.tsx
@@ -18,16 +18,16 @@ const StationSHMetro = (props: Props) => {
 
     return (
         <>
-            <use
-                xlinkHref={`#${stationIconStyle}`}
-                stroke='var(--rmg-theme-colour)'
-            />
             <StationNameGElement
                 name={stnInfo.name}
                 infos={stnInfo.transfer.info}
                 stnState={props.stnState}
                 direction={param.direction}
                 nameDirection={props.nameDirection}
+            />
+            <use
+                xlinkHref={`#${stationIconStyle}`}
+                stroke='var(--rmg-theme-colour)'
             />
         </>
     );
@@ -49,19 +49,18 @@ const StationNameGElement = (props: StationNameGElementProps) => {
             <line
                 x1={-30}
                 x2={30}
-                y1={props.nameDirection === 'upward' ? -33 : 0}
-                y2={props.nameDirection === 'upward' ? -33 : 0}
+                y1={props.nameDirection === 'upward' ? -23 : -10}
+                y2={props.nameDirection === 'upward' ? -23 : -10}
                 stroke='black'
             />
             <line
-                y1={props.nameDirection === 'upward' ? -33 : 0}
-                y2={props.nameDirection === 'upward' ? -33 - 17 : 20}
+                y1={props.nameDirection === 'upward' ? -23 : -10}
+                y2={props.nameDirection === 'upward' ? -23 - 25 : 20}
                 stroke='black'
             />
 
             {props.infos.reduce((sum, infos) => sum + infos.length, 0) && (<IntBoxGroup
                 intInfos={props.infos[1] ? ([] as InterchangeInfo[]).concat(...props.infos) : props.infos[0]}
-                transform={`translate(0,-10.75)`}
                 arrowDirection={props.nameDirection}
             />)}
 
@@ -88,7 +87,7 @@ const StationName = React.forwardRef(
 
         return (
             <g ref={ref} {...others} textAnchor='middle'
-                transform={`translate(0,${nameDirection === 'upward' ? -14.15625 - 2 : -14.15625 - 2 - 12 * (nameENLn - 1)})`}>
+                transform={`translate(0,${nameDirection === 'upward' ? -2 : -30 - 12 * (nameENLn - 1)})`}>
                 {React.useMemo(
                     () => (
                         <>
@@ -169,11 +168,8 @@ const IntBoxGroup = (props: { intInfos: InterchangeInfo[]; arrowDirection: 'upwa
 
         </>)}
 
-        <g
-            transform={`translate(0,${arrowDirection === 'upward' ? -130 : 105})`}
-            textAnchor="middle"
-            fontSize="66%">
-            <text className="rmg-name__zh" dy={-5}>
+        <g transform={`translate(0,${arrowDirection === 'upward' ? -140 : 120})`} textAnchor="middle">
+            <text className="rmg-name__zh" dy={-7}>
                 {`换乘${lineNames}`}
             </text>
             <text className="rmg-name__en" dy={5} fontSize="75%">
@@ -201,6 +197,6 @@ const OSIText = (props: { osiInfos: InterchangeInfo[] }) => {
             </g>
         ),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [lineNames.toString()]
+        [lineNames]
     );
 };

--- a/src/svgs/indoor/station-shmetro.tsx
+++ b/src/svgs/indoor/station-shmetro.tsx
@@ -172,7 +172,7 @@ const IntBoxGroup = (props: { intInfos: InterchangeInfo[]; arrowDirection: 'upwa
             <text className="rmg-name__zh" dy={-7}>
                 {`换乘${lineNames}`}
             </text>
-            <text className="rmg-name__en" dy={5} fontSize="75%">
+            <text className="rmg-name__en" dy={5} fontSize={9.6}>
                 {`Interchange Line ${lineNamesEn}`}
             </text>
         </g>

--- a/src/svgs/indoor/station-shmetro.tsx
+++ b/src/svgs/indoor/station-shmetro.tsx
@@ -71,7 +71,7 @@ const StationNameGElement = (props: StationNameGElementProps) => {
             />
 
             {props.infos[1]?.length && (
-                <g transform={`translate(0,${props.nameDirection === 'upward' ? -160 : 130})`}>
+                <g transform={`translate(0,${props.nameDirection === 'upward' ? -185 : 150})`}>
                     <OSIText osiInfos={props.infos[1]} />
                 </g>
             )}
@@ -168,7 +168,7 @@ const IntBoxGroup = (props: { intInfos: InterchangeInfo[]; arrowDirection: 'upwa
 
         </>)}
 
-        <g transform={`translate(0,${arrowDirection === 'upward' ? -140 : 120})`} textAnchor="middle">
+        <g transform={`translate(0,${arrowDirection === 'upward' ? -145 : 125})`} textAnchor="middle">
             <text className="rmg-name__zh" dy={-7}>
                 {`换乘${lineNames}`}
             </text>

--- a/src/svgs/indoor/station-shmetro.tsx
+++ b/src/svgs/indoor/station-shmetro.tsx
@@ -71,7 +71,7 @@ const StationNameGElement = (props: StationNameGElementProps) => {
             />
 
             {props.infos[1]?.length && (
-                <g transform={`translate(0,${props.nameDirection==='upward'?-160:130})`}>
+                <g transform={`translate(0,${props.nameDirection === 'upward' ? -160 : 130})`}>
                     <OSIText osiInfos={props.infos[1]} />
                 </g>
             )}
@@ -133,7 +133,7 @@ const IntBoxGroup = (props: { intInfos: InterchangeInfo[]; arrowDirection: 'upwa
             .join('，')].filter(name => name && name !== '号线').join('，')
     const lineNamesEn = intInfos
         .map(intInfo => intInfo[5].replace('Line', '')
-                        .replace('line', '').trim())
+            .replace('line', '').trim())
         .join(',')
 
     return (<g>


### PR DESCRIPTION
This PR should address serveral problems mentioned in #106 and #110.

To be specific:

* 3bedb95 fixed `title position` and `interchange legend position` to be at a fixed location
* 335ae0a fixed `line in central`
* 27c2f84 fixed `station icon on top` and `interchange arrow is longer and bigger` 

![image](https://user-images.githubusercontent.com/3353040/129468204-7e4d8652-1d8b-4de1-b1a1-9c72f0998010.png)
![image](https://user-images.githubusercontent.com/3353040/129468212-73841991-368c-48b2-9879-939e47a9ca06.png)
![image](https://user-images.githubusercontent.com/3353040/129468218-16071531-22a0-4eb5-8420-10d3c76c072c.png)
![image](https://user-images.githubusercontent.com/3353040/129468492-f11ab9f6-2e6d-4840-b49e-d8d7217b376f.png)

---

PS: `Interchange legend location` is still a fixed value as overlapping the legend is still unusable if the svg width is too small. There is no difference between fixed left of notice or dynamic right of the start of the canvas if the svg width is too small.
