### PR TITLE
#63 Save rmg style in param

### DIFF
--- a/src/app-appbar.tsx
+++ b/src/app-appbar.tsx
@@ -66,7 +66,7 @@ const CanvasToggle = () => {
     const classes = useStyles();
     const dispatch = useAppDispatch();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
 
     const [canvasButtonEl, setCanvasButtonEl] = React.useState<null | HTMLElement>(null);
     const handleClick = (action: CanvasType | typeof AllCanvas) => () => {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -169,6 +169,7 @@ export enum PanelTypeShmetro {
 export interface RMGParam {
     svgWidth: Record<CanvasType, number>;
     svg_height: number;
+    style: RmgStyle;
     /**
      * Vertical position (in percentage) of line.
      */

--- a/src/constants/templates/basic/blank.ts
+++ b/src/constants/templates/basic/blank.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     svg_width: 800,
     svg_dest_width: 1000,

--- a/src/constants/templates/basic/default.ts
+++ b/src/constants/templates/basic/default.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     svg_width: 1050,
     svg_dest_width: 1050,
@@ -155,7 +156,6 @@ const params = {
     line_name: ['路線名', 'Name of Line'],
     dest_legacy: false,
     char_form: 'trad',
-    style: 'mtr',
 };
 
 export default params;

--- a/src/constants/templates/bjsubway/bj1.ts
+++ b/src/constants/templates/bjsubway/bj1.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 450,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/bjsubway/bj4.ts
+++ b/src/constants/templates/bjsubway/bj4.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 450,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/bjsubway/bj5.ts
+++ b/src/constants/templates/bjsubway/bj5.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 450,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/bjsubway/bj6.ts
+++ b/src/constants/templates/bjsubway/bj6.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 450,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/bjsubway/bj7.ts
+++ b/src/constants/templates/bjsubway/bj7.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 450,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/gzmtr/gf.ts
+++ b/src/constants/templates/gzmtr/gf.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 300,
     svg_width: 1400,
     svg_dest_width: 1000,

--- a/src/constants/templates/gzmtr/gz1.ts
+++ b/src/constants/templates/gzmtr/gz1.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 300,
     svg_width: 1150,
     svg_dest_width: 1150,

--- a/src/constants/templates/gzmtr/gz14.ts
+++ b/src/constants/templates/gzmtr/gz14.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 370,
     svg_width: 1300,
     svg_dest_width: 1100,

--- a/src/constants/templates/gzmtr/gz2.ts
+++ b/src/constants/templates/gzmtr/gz2.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 300,
     svg_width: 2100,
     svg_dest_width: 1200,

--- a/src/constants/templates/gzmtr/gz21.ts
+++ b/src/constants/templates/gzmtr/gz21.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 300,
     svg_width: 1150,
     svg_dest_width: 1150,

--- a/src/constants/templates/gzmtr/gz3.ts
+++ b/src/constants/templates/gzmtr/gz3.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 370,
     padding: 2.45,
     y_pc: 68.02,

--- a/src/constants/templates/gzmtr/gz4.ts
+++ b/src/constants/templates/gzmtr/gz4.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 300,
     svg_width: 1400,
     svg_dest_width: 1100,

--- a/src/constants/templates/gzmtr/gz5.ts
+++ b/src/constants/templates/gzmtr/gz5.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 300,
     svg_width: 1400,
     svg_dest_width: 1000,

--- a/src/constants/templates/gzmtr/gz6.ts
+++ b/src/constants/templates/gzmtr/gz6.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 300,
     svg_width: 2500,
     svg_dest_width: 1000,

--- a/src/constants/templates/gzmtr/gz7.ts
+++ b/src/constants/templates/gzmtr/gz7.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 300,
     svg_width: 1000,
     svg_dest_width: 1000,

--- a/src/constants/templates/gzmtr/gz8.ts
+++ b/src/constants/templates/gzmtr/gz8.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 300,
     padding: 2.300062293353778,
     y_pc: 40,

--- a/src/constants/templates/gzmtr/gz9.ts
+++ b/src/constants/templates/gzmtr/gz9.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'gzmtr',
     svg_height: 300,
     svg_width: 1000,
     svg_dest_width: 1000,

--- a/src/constants/templates/mlm/taipa.ts
+++ b/src/constants/templates/mlm/taipa.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     svg_width: 900,
     svg_dest_width: 1100,

--- a/src/constants/templates/mtr/ael.ts
+++ b/src/constants/templates/mtr/ael.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     svg_width: 1100,
     svg_dest_width: 1100,

--- a/src/constants/templates/mtr/drl.ts
+++ b/src/constants/templates/mtr/drl.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     padding: 23.02,
     y_pc: 40,

--- a/src/constants/templates/mtr/eal.ts
+++ b/src/constants/templates/mtr/eal.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     svg_width: 1000,
     svg_dest_width: 1050,

--- a/src/constants/templates/mtr/isl.ts
+++ b/src/constants/templates/mtr/isl.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     svg_width: 1200,
     svg_dest_width: 1000,

--- a/src/constants/templates/mtr/ktl.ts
+++ b/src/constants/templates/mtr/ktl.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     svg_width: 1100,
     svg_dest_width: 1100,

--- a/src/constants/templates/mtr/sile.ts
+++ b/src/constants/templates/mtr/sile.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     svg_width: 1000,
     svg_dest_width: 1000,

--- a/src/constants/templates/mtr/tkl.ts
+++ b/src/constants/templates/mtr/tkl.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     svg_width: 1000,
     svg_dest_width: 1000,

--- a/src/constants/templates/mtr/tml.ts
+++ b/src/constants/templates/mtr/tml.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     padding: 12.65,
     y_pc: 40,

--- a/src/constants/templates/mtr/twl.ts
+++ b/src/constants/templates/mtr/twl.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     svg_width: 1250,
     svg_dest_width: 1250,
@@ -169,7 +170,6 @@ const params = {
     line_name: ['荃灣綫', 'Tsuen Wan Line'],
     dest_legacy: false,
     char_form: 'trad',
-    style: 'mtr',
 };
 
 export default params;

--- a/src/constants/templates/njmetro/nj1.ts
+++ b/src/constants/templates/njmetro/nj1.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 321,
     padding: 2.836743495136327,
     y_pc: 49.6,

--- a/src/constants/templates/njmetro/nj10.ts
+++ b/src/constants/templates/njmetro/nj10.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/njmetro/nj2.ts
+++ b/src/constants/templates/njmetro/nj2.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 321,
     padding: 4.216780871148593,
     y_pc: 40,

--- a/src/constants/templates/njmetro/nj3.ts
+++ b/src/constants/templates/njmetro/nj3.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 321,
     padding: 8.750201061605276,
     y_pc: 44.84,

--- a/src/constants/templates/njmetro/nj4.ts
+++ b/src/constants/templates/njmetro/nj4.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 300,
     padding: 5,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh1.ts
+++ b/src/constants/templates/shmetro/sh1.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'mtr',
     svg_height: 400,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh1.ts
+++ b/src/constants/templates/shmetro/sh1.ts
@@ -1,5 +1,5 @@
 const params = {
-    style: 'mtr',
+    style: 'shmetro',
     svg_height: 400,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh10.ts
+++ b/src/constants/templates/shmetro/sh10.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 450,
     padding: 3,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh11.ts
+++ b/src/constants/templates/shmetro/sh11.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 500,
     padding: 2.88,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh12.ts
+++ b/src/constants/templates/shmetro/sh12.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 450,
     padding: 3.47,
     y_pc: 68.02,

--- a/src/constants/templates/shmetro/sh13.ts
+++ b/src/constants/templates/shmetro/sh13.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 450,
     padding: 3.47,
     y_pc: 68.02,

--- a/src/constants/templates/shmetro/sh15.ts
+++ b/src/constants/templates/shmetro/sh15.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 450,
     padding: 5.16,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh16.ts
+++ b/src/constants/templates/shmetro/sh16.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 450,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh17.ts
+++ b/src/constants/templates/shmetro/sh17.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 400,
     padding: 13,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh2.ts
+++ b/src/constants/templates/shmetro/sh2.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 500,
     padding: 3.47,
     y_pc: 68.02,

--- a/src/constants/templates/shmetro/sh5.ts
+++ b/src/constants/templates/shmetro/sh5.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 450,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh6.ts
+++ b/src/constants/templates/shmetro/sh6.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 450,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh7.ts
+++ b/src/constants/templates/shmetro/sh7.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 400,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh8.ts
+++ b/src/constants/templates/shmetro/sh8.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 400,
     padding: 8.750201061605276,
     y_pc: 40,

--- a/src/constants/templates/shmetro/sh9.ts
+++ b/src/constants/templates/shmetro/sh9.ts
@@ -1,4 +1,5 @@
 const params = {
+    style: 'shmetro',
     svg_height: 400,
     padding: 4.5,
     y_pc: 40,

--- a/src/panels/design/list-common.tsx
+++ b/src/panels/design/list-common.tsx
@@ -35,7 +35,7 @@ const DesignList = () => {
     const { t } = useTranslation();
     const dispatch = useAppDispatch();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     const lineName = useAppSelector(store => store.param.line_name);
     const theme = useAppSelector(store => store.param.theme);
 

--- a/src/panels/design/panel.tsx
+++ b/src/panels/design/panel.tsx
@@ -9,7 +9,7 @@ const DesignGZMTR = React.lazy(() => import(/* webpackChunkName: "panelDesignGZM
 const DesignShmetro = React.lazy(() => import(/* webpackChunkName: "panelDesignShmetro" */ './list-shmetro'));
 
 const DesignPanel = () => {
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     return (
         <Grid container spacing={3} justify="center" alignItems="flex-start">
             <Grid item xs={12} sm={10} md={7} lg={5}>

--- a/src/panels/layout/common.tsx
+++ b/src/panels/layout/common.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles(theme =>
 );
 
 export default memo(function LayoutCommon() {
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     return (
         <>
             <SizeLi />
@@ -64,7 +64,7 @@ const SizeLi = () => {
     const classes = useStyles();
     const dispatch = useAppDispatch();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     const svgHeight = useAppSelector(store => store.param.svg_height);
     const svgWidths = useAppSelector(store => store.param.svgWidth);
 

--- a/src/panels/layout/panel.tsx
+++ b/src/panels/layout/panel.tsx
@@ -7,7 +7,7 @@ import { RmgStyle } from '../../constants/constants';
 const LayoutGZMTR = React.lazy(() => import(/* webpackChunkName: "panelLayoutGZMTR" */ './gzmtr'));
 
 export default React.memo(function LayoutPanel() {
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     return (
         <Grid container spacing={3} justify="center" alignItems="flex-start">
             <Grid item xs={12} sm={10} md={7} lg={5}>

--- a/src/panels/save/export-diag/dialog.tsx
+++ b/src/panels/save/export-diag/dialog.tsx
@@ -14,7 +14,7 @@ interface Props {
 export default function ExportDialog(props: Props) {
     const { t } = useTranslation();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     const canvasToShow = useAppSelector(store => store.app.canvasToShow);
 
     const [previewDialogOpened, setPreviewDialogOpened] = React.useState(false);

--- a/src/panels/save/export-diag/preview-diag.tsx
+++ b/src/panels/save/export-diag/preview-diag.tsx
@@ -73,7 +73,7 @@ export default function PreviewDialog(props: Props) {
     const { t } = useTranslation();
     const classes = useStyles();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
 
     const [svgEl, setSvgEl] = useState(document.createElement('svg') as Element as SVGSVGElement);
     const [isLoaded, setIsLoaded] = useState(false);

--- a/src/panels/save/panel.tsx
+++ b/src/panels/save/panel.tsx
@@ -21,6 +21,7 @@ import { Link } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../redux';
 import { LanguageCode, RmgStyle } from '../../constants/constants';
 import { setRmgStyle } from '../../redux/app/action';
+import { setStyle } from '../../redux/param/action';
 
 const TemplateDialog = React.lazy(() => import(/* webpackChunkName: "panelSaveTemplateDialog" */ './template-diag'));
 
@@ -150,7 +151,10 @@ function StyleDialog(props: StyleDialogProps) {
     const dispatch = useAppDispatch();
 
     const handleClose = (key: RmgStyle) => () => {
-        dispatch(setRmgStyle(key));
+        // Yeah, the following two lines are confusing.
+        // Sorry but style is needed in both app and param.
+        dispatch(setRmgStyle(key));  // set in App
+        dispatch(setStyle(key));  // set in param
         props.onClose(key);
     };
 

--- a/src/panels/save/panel.tsx
+++ b/src/panels/save/panel.tsx
@@ -20,7 +20,6 @@ import ExportDialog from './export-diag';
 import { Link } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../redux';
 import { LanguageCode, RmgStyle } from '../../constants/constants';
-import { setRmgStyle } from '../../redux/app/action';
 import { setStyle } from '../../redux/param/action';
 
 const TemplateDialog = React.lazy(() => import(/* webpackChunkName: "panelSaveTemplateDialog" */ './template-diag'));
@@ -46,7 +45,7 @@ const allLangs = {
 const SaveLists = () => {
     const { t, i18n } = useTranslation();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     const param = useAppSelector(store => store.param);
 
     const [isTempDialogOpen, setIsTempDialogOpen] = useState(false);
@@ -151,10 +150,7 @@ function StyleDialog(props: StyleDialogProps) {
     const dispatch = useAppDispatch();
 
     const handleClose = (key: RmgStyle) => () => {
-        // Yeah, the following two lines are confusing.
-        // Sorry but style is needed in both app and param.
-        dispatch(setRmgStyle(key));  // set in App
-        dispatch(setStyle(key));  // set in param
+        dispatch(setStyle(key));
         props.onClose(key);
     };
 

--- a/src/panels/save/template-diag/dialog.tsx
+++ b/src/panels/save/template-diag/dialog.tsx
@@ -82,6 +82,8 @@ const NewDialog = (props: TemplateDialogProps) => {
             await window.rmgStorage.writeFile('rmgParam', JSON.stringify(module.default));
             // TODO: electron will fail here, wait for #96
             window.location.assign(`./${module.default.style}`);
+            // So after #96 is fixed, we first need to dispatch the param
+            // and then <Link> to the module.default.style
         } catch (err) {
             console.error(err);
         }

--- a/src/panels/save/template-diag/dialog.tsx
+++ b/src/panels/save/template-diag/dialog.tsx
@@ -81,7 +81,7 @@ const NewDialog = (props: TemplateDialogProps) => {
             );
             await window.rmgStorage.writeFile('rmgParam', JSON.stringify(module.default));
             // TODO: electron will fail here, wait for #96
-            window.location.reload(true);
+            window.location.assign(`./${module.default.style}`);
         } catch (err) {
             console.error(err);
         }

--- a/src/panels/save/upload-item.tsx
+++ b/src/panels/save/upload-item.tsx
@@ -44,7 +44,7 @@ export default function UploadLi() {
         if (action === 'accept') {
             try {
                 await window.rmgStorage.writeFile('rmgParam', JSON.stringify(importedParam));
-                window.location.reload(true);
+                window.location.assign(`./${importedParam.style}`);
             } catch (err) {
                 console.error(err);
             }

--- a/src/panels/save/upload-item.tsx
+++ b/src/panels/save/upload-item.tsx
@@ -12,7 +12,7 @@ import {
     DialogActions,
     Button,
 } from '@material-ui/core';
-import { RMGParam } from '../../constants/constants';
+import { RMGParam, RmgStyle } from '../../constants/constants';
 
 export default function UploadLi() {
     const { t } = useTranslation();
@@ -44,7 +44,10 @@ export default function UploadLi() {
         if (action === 'accept') {
             try {
                 await window.rmgStorage.writeFile('rmgParam', JSON.stringify(importedParam));
-                window.location.assign(`./${importedParam.style}`);
+                // TODO: electron will fail here, wait for #96
+                window.location.assign(`./${importedParam.style || RmgStyle.MTR}`);
+                // So after #96 is fixed, we first need to dispatch the param
+                // and then <Link> to the importedParam.style
             } catch (err) {
                 console.error(err);
             }

--- a/src/panels/stations/add-diag.tsx
+++ b/src/panels/stations/add-diag.tsx
@@ -99,7 +99,7 @@ export default React.memo(
         const classes = useStyles();
         const dispatch = useAppDispatch();
 
-        const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+        const rmgStyle = useAppSelector(store => store.param.style);
         const stnList = useAppSelector(store => store.param.stn_list);
         const { tpo } = useAppSelector(store => store.helper)
 

--- a/src/panels/stations/edit-diag/branch-tab.tsx
+++ b/src/panels/stations/edit-diag/branch-tab.tsx
@@ -59,7 +59,7 @@ interface BranchSelectSetProps {
 
 const BranchSelectSet = (props: BranchSelectSetProps) => {
     const { stnId, direction } = props;
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     const branchEntry = useAppSelector(store => store.param.stn_list[stnId].branch[direction]);
 
     return React.useMemo(
@@ -136,7 +136,7 @@ const BranchFirstItem = (props: ItemProps) => {
     const classes = useStyles();
     const dispatch = useAppDispatch();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     const stnList = useAppSelector(store => store.param.stn_list);
     const stnInfo = stnList[stnId];
     const branchEntry = stnInfo.branch[direction];

--- a/src/panels/stations/edit-diag/interchange-tab.tsx
+++ b/src/panels/stations/edit-diag/interchange-tab.tsx
@@ -39,7 +39,7 @@ const StationEditInterchangeTab = (props: { stnId: string }) => {
     const { t } = useTranslation();
     const dispatch = useAppDispatch();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     const theme = useAppSelector(store => store.param.theme);
     const { transfer } = useAppSelector(store => store.param.stn_list[stnId]);
 

--- a/src/panels/stations/edit-diag/more-tab.tsx
+++ b/src/panels/stations/edit-diag/more-tab.tsx
@@ -17,7 +17,7 @@ import { Facilities, RmgStyle, Services } from '../../../constants/constants';
 import { addStationService, removeStationService, updateStationFacility } from '../../../redux/param/action';
 
 export default memo(function MoreTab(props: { stnId: string }) {
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     const rmgStyleServices: { [s in RmgStyle]?: Services[] } = {
         [RmgStyle.GZMTR]: [Services.local, Services.express],
         [RmgStyle.SHMetro]: [Services.local, Services.express, Services.direct],

--- a/src/panels/stations/edit-diag/name-tab.tsx
+++ b/src/panels/stations/edit-diag/name-tab.tsx
@@ -22,7 +22,7 @@ interface Props {
 }
 
 const NameTab = (props: Props) => {
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
 
     return (
         <List component="div">
@@ -166,7 +166,7 @@ const NameInput = (props: Props) => {
     const classes = useStyles();
     const dispatch = useAppDispatch();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     const { name } = useAppSelector(store => store.param.stn_list[stnId]);
     return (
         <ListItem style={{ flexDirection: 'column' }}>

--- a/src/panels/stations/fabs.tsx
+++ b/src/panels/stations/fabs.tsx
@@ -31,7 +31,7 @@ interface Props {
 const StationFabs = React.memo(
     (props: Props) => {
         const { t } = useTranslation();
-        const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+        const rmgStyle = useAppSelector(store => store.param.style);
         const classes = useStyles();
         const [fabEl, setFabEl] = React.useState<null | HTMLElement>(null);
 

--- a/src/panels/stations/panel2.tsx
+++ b/src/panels/stations/panel2.tsx
@@ -27,7 +27,7 @@ const PanelStations2 = () => {
     const classes = useStyles();
     const dispatch = useAppDispatch();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
 
     const [stnSelected, setStnSelected] = useState('');
     const [isOpen, setIsOpen] = useState(false);

--- a/src/panels/stations/station-list.tsx
+++ b/src/panels/stations/station-list.tsx
@@ -74,7 +74,7 @@ const StationEntry = (props: { stnId: string; isSelected: boolean; onAction: (ac
     const classes = useStyles();
     const dispatch = useAppDispatch();
 
-    const rmgStyle = useAppSelector(store => store.app.rmgStyle);
+    const rmgStyle = useAppSelector(store => store.param.style);
     const stationInfo = useAppSelector(store => store.param.stn_list[stnId]);
 
     const name = stationInfo?.name || ['', ''];

--- a/src/redux/app/action.test.ts
+++ b/src/redux/app/action.test.ts
@@ -5,12 +5,10 @@ import {
     SET_CANVAS_SCALE_STATUS,
     SET_CANVAS_TO_SHOW,
     SET_CANVAS_TO_SHOW_STATUS,
-    SET_RMG_STYLE,
-    setRmgStyle,
     zoomIn,
     zoomOut,
 } from './action';
-import { CanvasType, LoadingStatus, RmgStyle } from '../../constants/constants';
+import { CanvasType, LoadingStatus } from '../../constants/constants';
 import { createMockAppStore } from '../../setupTests';
 
 const realStore = rootReducer.getState();
@@ -35,16 +33,6 @@ describe('Tests for app actions', () => {
     afterEach(() => {
         mockStore.clearActions();
         jest.clearAllMocks();
-    });
-
-    it('Can set rmgStyle to expected style', () => {
-        mockStore.dispatch(setRmgStyle(RmgStyle.GZMTR));
-
-        const actions = mockStore.getActions();
-        expect(actions).toHaveLength(1);
-        expect(
-            actions.find(action => action.type === SET_RMG_STYLE && action.rmgStyle === RmgStyle.GZMTR)
-        ).toBeDefined();
     });
 
     it('Can handle zoom in action correctly', async () => {

--- a/src/redux/app/action.ts
+++ b/src/redux/app/action.ts
@@ -8,11 +8,6 @@ export const SET_CANVAS_SCALE_STATUS = 'SET_CANVAS_SCALE_STATUS';
 export const SET_CANVAS_TO_SHOW = 'SET_CANVAS_TO_SHOW';
 export const SET_CANVAS_TO_SHOW_STATUS = 'SET_CANVAS_TO_SHOW_STATUS';
 
-export interface setRmgStyleAction {
-    type: typeof SET_RMG_STYLE;
-    rmgStyle: RmgStyle;
-}
-
 export interface setCanvasScaleAction {
     type: typeof SET_CANVAS_SCALE;
     canvasScale: number;
@@ -32,10 +27,6 @@ export interface setCanvasToShowStatusAction {
     type: typeof SET_CANVAS_TO_SHOW_STATUS;
     canvasToShowStatus: LoadingStatus;
 }
-
-export const setRmgStyle = (rmgStyle: RmgStyle) => {
-    return { type: SET_RMG_STYLE, rmgStyle } as setRmgStyleAction;
-};
 
 export const setCanvasScale = (canvasScale: number) => {
     return { type: SET_CANVAS_SCALE, canvasScale } as setCanvasScaleAction;

--- a/src/redux/app/reducer.ts
+++ b/src/redux/app/reducer.ts
@@ -4,12 +4,10 @@ import {
     SET_CANVAS_SCALE_STATUS,
     SET_CANVAS_TO_SHOW,
     SET_CANVAS_TO_SHOW_STATUS,
-    SET_RMG_STYLE,
     setCanvasScaleAction,
     setCanvasScaleStatusAction,
     setCanvasToShowAction,
     setCanvasToShowStatusAction,
-    setRmgStyleAction,
 } from './action';
 
 interface AppState {
@@ -31,16 +29,12 @@ const initialState: AppState = {
 export default function AppReducer(
     state = initialState,
     action:
-        | setRmgStyleAction
         | setCanvasScaleAction
         | setCanvasScaleStatusAction
         | setCanvasToShowAction
         | setCanvasToShowStatusAction
 ): AppState {
     switch (action.type) {
-        case SET_RMG_STYLE:
-            state.rmgStyle = action.rmgStyle;
-            break;
         case SET_CANVAS_SCALE:
             state.canvasScale = action.canvasScale;
             break;

--- a/src/redux/param/action.test.ts
+++ b/src/redux/param/action.test.ts
@@ -14,6 +14,7 @@ import {
     SET_NOTES,
     SET_STATION,
     SET_STATIONS_BULK,
+    SET_STYLE,
     setCustomisedMtrDestinationAction,
     setFullParam,
     setNamePositionAction,
@@ -21,6 +22,7 @@ import {
     setStation,
     setStationAction,
     setStationsBulk,
+    setStyle,
     staggerStationNames,
     toggleLineNameBeforeDestination,
     updateInterchange,
@@ -34,6 +36,7 @@ import {
     Name,
     Note,
     RMGParam,
+    RmgStyle,
     Services,
     StationDict,
     StationInfo,
@@ -84,6 +87,18 @@ const mockStationList = {
 } as any as StationDict;
 
 describe('Tests for param actions', () => {
+    it('Can set rmgStyle to expected style', () => {
+        const mockStore = createMockAppStore({ ...realStore });
+
+        mockStore.dispatch(setStyle(RmgStyle.GZMTR));
+
+        const actions = mockStore.getActions();
+        expect(actions).toHaveLength(1);
+        expect(
+            actions.find(action => action.type === SET_STYLE && action.style === RmgStyle.GZMTR)
+        ).toBeDefined();
+    });
+
     it('Can trigger helpers to update when setting stations', () => {
         let actions: any[];
 

--- a/src/redux/param/action.ts
+++ b/src/redux/param/action.ts
@@ -9,6 +9,7 @@ import {
     PanelTypeGZMTR,
     PanelTypeShmetro,
     RMGParam,
+    RmgStyle,
     Services,
     ShortDirection,
     StationDict,
@@ -19,6 +20,9 @@ import { AppDispatch, RootState } from '../index';
 import { triggerHelpersUpdate } from '../helper/action';
 
 export const SET_FULL_PARAM = 'SET_FULL_PARAM';
+
+// file
+export const SET_STYLE = 'SET_STYLE';
 
 // layout
 export const SET_SVG_HEIGHT = 'SET_SVG_HEIGHT';
@@ -49,6 +53,11 @@ export const SET_STATIONS_BULK = 'SET_STATIONS_BULK';
 export interface setFullParamAction {
     type: typeof SET_FULL_PARAM;
     fullParam: RMGParam;
+}
+
+export interface setStyleAction {
+    type: typeof SET_STYLE;
+    style: RmgStyle;
 }
 
 export interface setSvgHeightAction {
@@ -170,6 +179,10 @@ export const setSvgHeight = (svgHeight: number): setSvgHeightAction => {
 
 export const setSvgWidth = (svgWidth: number, canvas: CanvasType): setSvgWidthAction => {
     return { type: SET_SVG_WIDTH, svgWidth, canvas };
+};
+
+export const setStyle = (style: RmgStyle): setStyleAction => {
+    return { type: SET_STYLE, style };
 };
 
 export const setYPercentage = (yPercentage: number): setYPercentageAction => {

--- a/src/redux/param/reducer.ts
+++ b/src/redux/param/reducer.ts
@@ -1,5 +1,5 @@
 import { CityCode } from '../../constants/city-config';
-import { MonoColour, PanelTypeGZMTR, RMGParam, ShortDirection } from '../../constants/constants';
+import { MonoColour, PanelTypeGZMTR, RMGParam, ShortDirection, RmgStyle } from '../../constants/constants';
 import {
     SET_BRANCH_SPACING,
     SET_CURRENT_STATION,
@@ -22,6 +22,7 @@ import {
     SET_SVG_WIDTH,
     SET_THEME,
     SET_Y_PERCENTAGE,
+    SET_STYLE,
     setBranchSpacingAction,
     setCurrentStationAction,
     setCustomisedMtrDestinationAction,
@@ -43,6 +44,7 @@ import {
     setSvgWidthAction,
     setThemeAction,
     setYPercentageAction,
+    setStyleAction,
 } from './action';
 
 const initialState: RMGParam = {
@@ -53,6 +55,7 @@ const initialState: RMGParam = {
         indoor: 100,
     },
     svg_height: 100,
+    style: RmgStyle.MTR,
     y_pc: 50,
     padding: 10,
     branch_spacing: 10,
@@ -82,6 +85,7 @@ export default function ParamReducer(
     state = initialState,
     action:
         | setFullParamAction
+        | setStyleAction
         | setSvgHeightAction
         | setSvgWidthAction
         | setYPercentageAction
@@ -106,6 +110,9 @@ export default function ParamReducer(
     switch (action.type) {
         case SET_FULL_PARAM:
             return action.fullParam;
+        case SET_STYLE:
+            state.style = action.style;
+            break;
         case SET_SVG_HEIGHT:
             state.svg_height = action.svgHeight;
             break;

--- a/src/svgs/svg.tsx
+++ b/src/svgs/svg.tsx
@@ -3,7 +3,7 @@ import { CircularProgress, createStyles, makeStyles } from '@material-ui/core';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import ErrorBoundary from '../error-boundary';
 import { AllCanvas, canvasConfig, CanvasType, RmgStyle } from '../constants/constants';
-import { selectCanvas, setRmgStyle } from '../redux/app/action';
+import { selectCanvas } from '../redux/app/action';
 import { setStyle } from '../redux/param/action';
 import { useAppDispatch, useAppSelector } from '../redux';
 
@@ -78,7 +78,6 @@ const StyleSpecificSVGs = memo(
 
         const canvasToShow = useAppSelector(store => store.app.canvasToShow);
 
-        dispatch(setRmgStyle(props.style));
         dispatch(setStyle(props.style));
 
         useEffect(

--- a/src/svgs/svg.tsx
+++ b/src/svgs/svg.tsx
@@ -4,6 +4,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import ErrorBoundary from '../error-boundary';
 import { AllCanvas, canvasConfig, CanvasType, RmgStyle } from '../constants/constants';
 import { selectCanvas, setRmgStyle } from '../redux/app/action';
+import { setStyle } from '../redux/param/action';
 import { useAppDispatch, useAppSelector } from '../redux';
 
 const useStyles = makeStyles(() =>
@@ -78,6 +79,7 @@ const StyleSpecificSVGs = memo(
         const canvasToShow = useAppSelector(store => store.app.canvasToShow);
 
         dispatch(setRmgStyle(props.style));
+        dispatch(setStyle(props.style));
 
         useEffect(
             () => {


### PR DESCRIPTION
Successfully merging this PR will fix #63.

What the main change is to move the `rmgStyle` in app to `style` in param.

## `style` suffix in url

First thing first. The relation between `style` in param and `style` suffix in url will always be **IN SYNC**. This means whenever there is a change in style, the url, and the param will be updated. And vice versa, if a user changes the suffix in url or opens a new tab in the browser, the `style` in param is updated. 

The `style` will be updated in these cases:

- Choose a new template.
- Open from json.
- Every time style is selected (in `StyleSpecificSVGs`).
- Every time the app is initialized (by reading the url suffix).

## removal of `app.rmgStyle`

- Update all usage of `const rmgStyle = useAppSelector(store => store.app.rmgStyle);` to `const rmgStyle = useAppSelector(store => store.param.style);`.
- Remove the test case in `app` and add it in `param`.

## Backward compatibility

- Update all templates with `style` in them.
- Older json save file will be loaded with `importedParam.style || RmgStyle.MTR`.

## After #96 is fixed

We may remove the `window.location.assign` and `1)` dispatch the loaded param and `2)` `<Link>` to the style.

This should be feasible, right?
